### PR TITLE
Update to work with RES 2.3

### DIFF
--- a/active_event_store.gemspec
+++ b/active_event_store.gemspec
@@ -28,7 +28,7 @@ Gem::Specification.new do |s|
   # NOTE: RES is not following semantic versioning!
   # View changelog before upgrade. Gem is actively developing.
   # https://github.com/RailsEventStore/rails_event_store/releases
-  s.add_dependency "rails_event_store", ">= 0.42.0", "< 2"
+  s.add_dependency "rails_event_store", ">= 2.1.0"
 
   s.add_development_dependency "bundler", ">= 1.15"
   s.add_development_dependency "combustion", ">= 1.1"

--- a/lib/active_event_store/config.rb
+++ b/lib/active_event_store/config.rb
@@ -1,11 +1,13 @@
 # frozen_string_literal: true
 
+require "json"
+
 module ActiveEventStore
   class Config
     attr_writer :repository, :job_queue_name, :store_options
 
     def repository
-      @repository ||= RailsEventStoreActiveRecord::EventRepository.new
+      @repository ||= RailsEventStoreActiveRecord::EventRepository.new(serializer: JSON)
     end
 
     def job_queue_name

--- a/lib/active_event_store/config.rb
+++ b/lib/active_event_store/config.rb
@@ -4,10 +4,14 @@ require "json"
 
 module ActiveEventStore
   class Config
-    attr_writer :repository, :job_queue_name, :store_options
+    attr_writer :repository, :serializer, :job_queue_name, :store_options
 
     def repository
-      @repository ||= RailsEventStoreActiveRecord::EventRepository.new(serializer: JSON)
+      @repository ||= RailsEventStoreActiveRecord::EventRepository.new(serializer: serializer)
+    end
+
+    def serializer
+      @serializer ||= JSON
     end
 
     def job_queue_name

--- a/lib/active_event_store/engine.rb
+++ b/lib/active_event_store/engine.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 
 require "rails/engine"
+require "json"
 
 module ActiveEventStore
   class Engine < ::Rails::Engine
@@ -18,7 +19,9 @@ module ActiveEventStore
       # See https://railseventstore.org/docs/subscribe/#scheduling-async-handlers-after-commit
       ActiveEventStore.event_store = RailsEventStore::Client.new(
         dispatcher: RubyEventStore::ComposedDispatcher.new(
-          RailsEventStore::AfterCommitAsyncDispatcher.new(scheduler: RailsEventStore::ActiveJobScheduler.new),
+          RailsEventStore::AfterCommitAsyncDispatcher.new(
+            scheduler: RailsEventStore::ActiveJobScheduler.new(serializer: JSON)
+          ),
           RubyEventStore::Dispatcher.new
         ),
         repository: ActiveEventStore.config.repository,

--- a/lib/active_event_store/engine.rb
+++ b/lib/active_event_store/engine.rb
@@ -1,7 +1,6 @@
 # frozen_string_literal: true
 
 require "rails/engine"
-require "json"
 
 module ActiveEventStore
   class Engine < ::Rails::Engine
@@ -20,7 +19,9 @@ module ActiveEventStore
       ActiveEventStore.event_store = RailsEventStore::Client.new(
         dispatcher: RubyEventStore::ComposedDispatcher.new(
           RailsEventStore::AfterCommitAsyncDispatcher.new(
-            scheduler: RailsEventStore::ActiveJobScheduler.new(serializer: JSON)
+            scheduler: RailsEventStore::ActiveJobScheduler.new(
+              serializer: ActiveEventStore.config.serializer
+            )
           ),
           RubyEventStore::Dispatcher.new
         ),

--- a/lib/active_event_store/mapper.rb
+++ b/lib/active_event_store/mapper.rb
@@ -1,7 +1,5 @@
 # frozen_string_literal: true
 
-require "json"
-
 module ActiveEventStore
   using(Module.new {
     refine Hash do
@@ -15,7 +13,7 @@ module ActiveEventStore
   #
   # See https://github.com/RailsEventStore/rails_event_store/blob/v0.35.0/ruby_event_store/lib/ruby_event_store/mappers/default.rb
   class Mapper
-    def initialize(mapping:, serializer: JSON)
+    def initialize(mapping:, serializer: ActiveEventStore.config.serializer)
       @serializer = serializer
       @mapping = mapping
     end

--- a/lib/active_event_store/mapper.rb
+++ b/lib/active_event_store/mapper.rb
@@ -3,13 +3,13 @@
 require "json"
 
 module ActiveEventStore
-  using(Module.new do
+  using(Module.new {
     refine Hash do
       def symbolize_keys
         RubyEventStore::TransformKeys.symbolize(self)
       end
     end
-  end)
+  })
 
   # Custom mapper for RES events.
   #
@@ -20,25 +20,27 @@ module ActiveEventStore
       @mapping = mapping
     end
 
-    def event_to_serialized_record(domain_event)
+    def event_to_record(domain_event)
       # lazily add type to mapping
       # NOTE: use class name instead of a class to handle code reload
       # in development (to avoid accessing orphaned classes)
       mapping.register(domain_event.event_type, domain_event.class.name) unless mapping.exist?(domain_event.event_type)
 
-      RubyEventStore::SerializedRecord.new(
+      RubyEventStore::Record.new(
         event_id: domain_event.event_id,
         metadata: serializer.dump(domain_event.metadata.to_h),
         data: serializer.dump(domain_event.data),
-        event_type: domain_event.event_type
+        event_type: domain_event.event_type,
+        timestamp: domain_event.timestamp,
+        valid_at: domain_event.valid_at
       )
     end
 
-    def serialized_record_to_event(record)
-      event_class = mapping.fetch(record.event_type) do
+    def record_to_event(record)
+      event_class = mapping.fetch(record.event_type) {
         raise "Don't know how to deserialize event: \"#{record.event_type}\". " \
               "Add explicit mapping: ActiveEventStore.mapping.register \"#{record.event_type}\", \"<Class Name>\""
-      end
+      }
 
       Object.const_get(event_class).new(
         **serializer.load(record.data).symbolize_keys,

--- a/lib/active_event_store/rspec/have_enqueued_async_subscriber_for.rb
+++ b/lib/active_event_store/rspec/have_enqueued_async_subscriber_for.rb
@@ -21,7 +21,7 @@ module ActiveEventStore
       end
 
       def matches?(actual_serialized)
-        actual = ActiveEventStore.event_store.deserialize(actual_serialized)
+        actual = ActiveEventStore.event_store.deserialize(actual_serialized, serializer: JSON)
 
         actual.event_type == event.event_type && data_matches?(actual.data)
       end
@@ -62,9 +62,9 @@ module ActiveEventStore
 end
 
 RSpec.configure do |config|
-  config.include(Module.new do
+  config.include(Module.new {
     def have_enqueued_async_subscriber_for(*args)
       ActiveEventStore::HaveEnqueuedAsyncSubscriberFor.new(*args)
     end
-  end)
+  })
 end

--- a/lib/active_event_store/rspec/have_enqueued_async_subscriber_for.rb
+++ b/lib/active_event_store/rspec/have_enqueued_async_subscriber_for.rb
@@ -21,7 +21,10 @@ module ActiveEventStore
       end
 
       def matches?(actual_serialized)
-        actual = ActiveEventStore.event_store.deserialize(actual_serialized, serializer: JSON)
+        actual = ActiveEventStore.event_store.deserialize(
+          actual_serialized,
+          serializer: ActiveEventStore.config.serializer
+        )
 
         actual.event_type == event.event_type && data_matches?(actual.data)
       end

--- a/lib/active_event_store/subscriber_job.rb
+++ b/lib/active_event_store/subscriber_job.rb
@@ -38,7 +38,7 @@ module ActiveEventStore
     end
 
     def perform(payload)
-      event = event_store.deserialize(**payload, serializer: JSON)
+      event = event_store.deserialize(**payload, serializer: ActiveEventStore.config.serializer)
 
       event_store.with_metadata(**event.metadata.to_h) do
         subscriber.call(event)

--- a/lib/active_event_store/subscriber_job.rb
+++ b/lib/active_event_store/subscriber_job.rb
@@ -38,7 +38,7 @@ module ActiveEventStore
     end
 
     def perform(payload)
-      event = event_store.deserialize(payload)
+      event = event_store.deserialize(**payload, serializer: JSON)
 
       event_store.with_metadata(**event.metadata.to_h) do
         subscriber.call(event)

--- a/spec/mapper_spec.rb
+++ b/spec/mapper_spec.rb
@@ -10,9 +10,9 @@ describe ActiveEventStore::Mapper do
 
   subject { described_class.new(mapping: mapping) }
 
-  describe "#event_to_serialized_record" do
+  describe "#event_to_record" do
     it "works", :aggregate_failures do
-      record = subject.event_to_serialized_record(event)
+      record = subject.event_to_record(event)
 
       expect(record.event_type).to eq "test_event"
       expect(record.data).to eq({user_id: 1, action_type: "test"}.to_json)
@@ -23,16 +23,16 @@ describe ActiveEventStore::Mapper do
     specify "with sync attributes" do
       event = event_class.new(user_id: 1, user: {name: "Sara"}, action_type: "test", metadata: {timestamp: 321})
 
-      record = subject.event_to_serialized_record(event)
+      record = subject.event_to_record(event)
       expect(record.data).to eq({user_id: 1, action_type: "test"}.to_json)
     end
   end
 
-  describe "#serialized_record_to_event" do
-    let(:record) { subject.event_to_serialized_record(event) }
+  describe "#record_to_event" do
+    let(:record) { subject.event_to_record(event) }
 
     it "works", :aggregate_failures do
-      new_event = subject.serialized_record_to_event(record)
+      new_event = subject.record_to_event(record)
 
       expect(new_event).to eq event
     end
@@ -40,7 +40,7 @@ describe ActiveEventStore::Mapper do
     it "raises error if unknown event type" do
       mapper = described_class.new(mapping: ActiveEventStore::Mapping.new)
 
-      expect { mapper.serialized_record_to_event(record) }
+      expect { mapper.record_to_event(record) }
         .to raise_error(/don't know how to deserialize event: "test_event"/i)
     end
 
@@ -49,7 +49,7 @@ describe ActiveEventStore::Mapper do
 
       mapping.register "test_event", "ActiveEventStore::TestEvent"
 
-      new_event = mapper.serialized_record_to_event(record)
+      new_event = mapper.record_to_event(record)
       expect(new_event).to eq event
     end
   end


### PR DESCRIPTION
## What is the purpose of this pull request?

To update the gem to work with the current version of Rails Event Store (v2.3). Fixes #3.

This is not complete but is still a work in progress. It needs some help to get over the finish line.

## What changes did you make?

I tried to get all tests passing (still one failure on a custom matcher) and followed the recommendations in https://github.com/RailsEventStore/rails_event_store/blob/master/railseventstore.org/source/docs/v2/custom_components_2_0.html.md.

I am considering using RES in a project and very much prefer the interface this gem provides so I wanted to attempt to get it working. That said, though I have 16 years of Ruby and Rails experience, I haven't previously used RES or this gem.

## Is there anything you'd like reviewers to focus on?

Although my changes have gotten tests to pass, I'm not sure if they are really the optimal solution. Some things I noticed:
- I had to pass in `serializer: JSON` multiple times. That should probably be dried up in configuration setting.
- Ideally (maybe a different PR), I'd like to see the ability to store event data and metadata in JSONB fields vs. text fields for easier direct querying. I think a setting that would configure that would be ideal but I didn't introduce that in this PR.
- There is still a broken test within the custom matchers.

## Checklist

- [ ] I've added tests for this change
- [ ] I've added a Changelog entry
- [ ] I've updated a documentation
