### PR TITLE
Add support to classes that inherit from Class as async subscribers.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## master
 
+## 1.0.2 (2022-03-11)
+
+- Add support to classes that inherit from Class as async subscribers ([@caws][])
+
 ## 1.0.1 (2021-09-16)
 
 - Add minitest assertions: `assert_event_published`, `refute_event_published`, `assert_async_event_subscriber_enqueued`  ([@chriscz][])

--- a/README.md
+++ b/README.md
@@ -140,7 +140,7 @@ ActiveSupport.on_load :active_event_store do |store|
 end
 ```
 
-Subscribers could be any callable Ruby objects that accept a single argument (event) as its input.
+Subscribers could be any callable Ruby objects that accept a single argument (event) as its input or classes that inherit from Class` and have `#call` as an instance method.
 
 We suggest putting subscribers to the `app/subscribers` folder using the following convention: `app/subscribers/on_<event_type>/<subscriber.rb>`, e.g. `app/subscribers/on_profile_created/create_chat_user.rb`.
 

--- a/lib/active_event_store/subscriber_job.rb
+++ b/lib/active_event_store/subscriber_job.rb
@@ -41,7 +41,11 @@ module ActiveEventStore
       event = event_store.deserialize(**payload, serializer: ActiveEventStore.config.serializer)
 
       event_store.with_metadata(**event.metadata.to_h) do
-        subscriber.call(event)
+        if subscriber.is_a?(Class) && !subscriber.respond_to?(:call)
+          subscriber.new.call(event)
+        else
+          subscriber.call(event)
+        end
       end
     end
 

--- a/lib/active_event_store/version.rb
+++ b/lib/active_event_store/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module ActiveEventStore # :nodoc:
-  VERSION = "1.0.1"
+  VERSION = "1.0.2"
 end


### PR DESCRIPTION
<!--
  First of all, thanks for contributing!

  If it's a typo fix or minor documentation update feel free to skip the rest of this template!
-->

## What is the purpose of this pull request?

<!--
  If it's a bug fix, then link it to the issue, for example:

  Fixes #xxx
-->

This PR adds support to classes that inherit from `Class` as async subscribers.
More info can be found at #8 

Much like what RES does when dispatching events to subscribers, in order to support classes that inherit from `Class` it is necessary to check if a given subscriber is a `Class` and if it does not contain a class method called `#call`.

If that asserts to true, the #call method must be invoked on an instance of the subscriber being passed, much like what RES does when dispatching events to subscribers ([see here](https://github.com/RailsEventStore/rails_event_store/blob/d8fd215e2b7b2cba651fbc3a68e9a8f82b572d27/ruby_event_store/lib/ruby_event_store/dispatcher.rb#L6))

The specs contain a bit more context on this.

## What changes did you make? (overview)

Instead of calling `subscribe.call(event)` directly, [it now checks if subscriber is a Class and if it does not implement `#call` as a class method.](https://github.com/caws/active_event_store/blob/655af038b5284923a624fab68942971e3105a34a/lib/active_event_store/subscriber_job.rb#L44)

Before:

````ruby
  class SubscriberJob < ActiveJob::Base
    ...
    def perform(payload)
      event = event_store.deserialize(**payload, serializer: ActiveEventStore.config.serializer)

      event_store.with_metadata(**event.metadata.to_h) do
          subscriber.call(event)
      end
    ...
    end
  end
````

After:

````ruby
  class SubscriberJob < ActiveJob::Base
    ...
    def perform(payload)
      event = event_store.deserialize(**payload, serializer: ActiveEventStore.config.serializer)

      event_store.with_metadata(**event.metadata.to_h) do
        if subscriber.is_a?(Class) && !subscriber.respond_to?(:call)
          subscriber.new.call(event)
        else
          subscriber.call(event)
        end
      end
    ...
    end
  end
````

## Is there anything you'd like reviewers to focus on?

## Checklist

- [x] I've added tests for this change
- [x] I've added a Changelog entry
- [x] I've updated a documentation
