### PR TITLE
Drop rubocop target version as it's inferred

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -16,7 +16,6 @@ AllCops:
     - 'spec/internal/db/**/*'
   DisplayCopNames: true
   SuggestExtensions: false
-  TargetRubyVersion: 2.7
 
 Standard/BlockSingleLineBraces:
   Enabled: false


### PR DESCRIPTION
A small change to reduce chore in the future. Rubocop supports inference of the version from gemspec as per https://docs.rubocop.org/rubocop/1.56/configuration.html#setting-the-target-ruby-version