### PR TITLE
updates event registration README instruction

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,10 +87,10 @@ You can also register events manually:
 
 ```ruby
 # by passing an event class
-ActiveEventStore.mapper.register_event MyEventClass
+ActiveEventStore.mapping.register_event MyEventClass
 
 # or more precisely (in that case `event.type` must be equal to "my_event")
-ActiveEventStore.mapper.register "my_event", MyEventClass
+ActiveEventStore.mapping.register "my_event", MyEventClass
 ```
 
 ### Publish events


### PR DESCRIPTION
 
<!--
  First of all, thanks for contributing!

  If it's a typo fix or minor documentation update feel free to skip the rest of this template!
-->

## What is the purpose of this pull request?

<!--
  If it's a bug fix, then link it to the issue, for example:

  Fixes #xxx
-->

## What changes did you make? (overview)

Looks like the correct way to register an event is

```
ActiveEventStore.mapping.register_event MyEventClass
```
or 

```
ActiveEventStore.mapping.register "my_event", MyEventClass
```
This PR updates the READMe to reflect this.

## Is there anything you'd like reviewers to focus on?

Please confirm the readme updates are correct.

## Checklist

- [ ] I've added tests for this change
- [ ] I've added a Changelog entry
- [x] I've updated a documentation
