### PR TITLE
Define Rails.configuration.event_store after initialization

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## master
 
+- Updates the railtie to define `Rails.configuration.event_store`. ([@Samsinite][])
+
 ## 1.2.0 (2024-01-25)
 
 - Use custom pipeline mapper and domain event transformer. ([@Samsinite][])

--- a/lib/active_event_store/engine.rb
+++ b/lib/active_event_store/engine.rb
@@ -29,6 +29,7 @@ module ActiveEventStore
         mapper: ActiveEventStore::Mapper.new(mapping: ActiveEventStore.mapping),
         **ActiveEventStore.config.store_options
       )
+      Rails.configuration.event_store = ActiveEventStore.event_store
 
       ActiveSupport.run_load_hooks(:active_event_store, ActiveEventStore)
     end


### PR DESCRIPTION
This commit updates ActiveEventStore to define Rails.configuration.event_store after the event store has been initialized. Fixes #17

## What is the purpose of this pull request?
Defines `Rails.configuration.event_store` after the event store is initialized, so that the rails event store browser tools (and other tools) should ideally just work out of the box.   Fixes #17 

## Checklist

- [ ] I've added tests for this change
- [x] I've added a Changelog entry
- [ ] I've updated a documentation
